### PR TITLE
Resolve all content dir paths to their realpathed version

### DIFF
--- a/classes/Turbo.php
+++ b/classes/Turbo.php
@@ -87,6 +87,7 @@ final class Turbo
         }
 
         $root = $this->kirby->root('content') ?? '';
+        $root = realpath($root) ?: '';
 
         // preloaded data as json
         if (strlen($output) > 2 &&
@@ -194,6 +195,7 @@ final class Turbo
         if (! is_string($root) || $root === '') {
             return '';
         }
+        $root = realpath($root) ?: $root;
         $exec = escapeshellcmd($this->options['inventory.indexer']);
         $patterns = implode(',', $this->modelsWithTurboFilenamePatterns());
         $cmd = $exec.' --dir '.escapeshellarg($root).' --filenames '.escapeshellarg($patterns); // patterns used to filter which files tread content
@@ -210,6 +212,7 @@ final class Turbo
         if (! is_string($root) || $root === '') {
             return '';
         }
+        $root = realpath($root) ?: $root;
         $exec = escapeshellcmd($this->options['inventory.indexer']);
         /* all files need to be scanned
         $patterns = implode(' -o ', array_map(
@@ -218,7 +221,7 @@ final class Turbo
         ));
         $cmd = "{$exec} '{$root}' -type f \( $patterns \)";
         */
-        $cmd = $exec.' '.escapeshellarg($root).' -type f';
+        $cmd = $exec . ' -L ' . escapeshellarg($root) . ' -type f';
         if ($this->options['inventory.modified']) {
             $statFlag = '-f';
             $statFormat = "%N\t%m";

--- a/classes/TurboDir.php
+++ b/classes/TurboDir.php
@@ -108,14 +108,12 @@ class TurboDir extends Dir
             'template' => 'default',
         ];
 
-        // NOTE: changed to use TURBO by @bnomei
-        /*
+        // resolve symlinks so the path matches turbo cache keys
         $dir = realpath($dir);
 
         if ($dir === false) {
             return $inventory;
         }
-        */
 
         // a temporary store for all content files
         $content = [];


### PR DESCRIPTION
Kirby uses `realpath()`-resolved directories internally for storage file paths. When the content directory is a symlink, Kirby looks up cache keys using the realpathed path, but Turbo had stored the symlinked path as the cache key — causing lookup misses. 

## Changes                                                                                                                         
                                                         
   - **`TurboDir.php`**: Restore the `realpath($dir)` call that was previously commented out, so directory paths are resolved before inventory traversal.
   - **`Turbo.php`**: Apply `realpath()` consistently in `execWithTurbo()` and `execWithFind()` so the content root passed to external   indexers matches Kirby's internal path representation.
   - **`Turbo.php` (`execWithFind`)**: Add `-L` flag to `find` so it follows symlinks during traversal. 
   
This closes #3, but maybe there was a reason why `realpath` was commented out in `TurboDir`? 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbolic link handling across directory traversal operations
  * Enhanced path normalization for file system access
  * Directory inventory now properly resolves symbolic links during operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->